### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/DCA_package.yml
+++ b/.github/workflows/DCA_package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: DCA Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/decline-curve-analysis/security/code-scanning/2](https://github.com/equinor/decline-curve-analysis/security/code-scanning/2)

The best way to fix the problem is to specify an explicit `permissions` block in the workflow file. This can be done at the root level (recommended unless jobs need different permissions), or individually within each job. Since neither job in this workflow appears to require elevated privileges (no code pushes, artifact uploads, or access to issues), the minimal permissions block should be set to `contents: read` for all jobs. This change should be made directly below the `name` key at the top of the workflow (after line 4), applying the restriction to every job unless a job-specific block is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
