### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dca"
-version = "2.0.0"
+version = "2.1.0"
 description = "Decline Curve Analysis"
 requires-python = ">= 3.9"
 readme = {file = "README.md", content-type = "text/markdown"}


### PR DESCRIPTION
Bump to version 2.1.0 (this will be taged). New since 2.0 is various bug fixes, some system stuff (GHAS etc) and some user info (faq, etc)