### PR TITLE
Downgrade ipython version in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 license = "MIT" 
 dependencies = [
-    "ipython>=9.13.0",
+    "ipython>=9.12.0",
     "matplotlib>=3.10.9",
     "numpy>=2.4.4",
     "openpyxl>=3.1.5",


### PR DESCRIPTION
Downgrade ipython dependency from 9.13.0 to 9.12.0

Closes #70 